### PR TITLE
The driver is always using latin characterset

### DIFF
--- a/mysql.c
+++ b/mysql.c
@@ -177,7 +177,8 @@ Ns_MySQL_OpenDb(Ns_DbHandle *handle)
         ns_free(datasource);
         return NS_ERROR;
     }
-
+    //set the default characterset to utf8
+    mysql_set_character_set(dbh, "utf8");
     ns_free(datasource);
 
     handle->connection = (void *) dbh;


### PR DESCRIPTION
set the default characterset to utf8 to support Arabic
